### PR TITLE
0.1.2 - adds options V2 page, allows whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ https://chrome.google.com/webstore/detail/gif-delayer/cmfcdkambpljcndgdmaccaagla
 Change Log
 ==========
 
+0.1.2
+- add whitelist of sites to disable this extension on certain sites using chrome options V2
+
 0.0.8
 - fix bug overriding default gif styling on certain websites (thanks to [Marc Cornellà](https://github.com/mcornella))
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gif Delayer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "manifest_version": 2,
   "description": "Gif Delayer delays playing gifs until they are fully downloaded.",
   "homepage_url": "https://github.com/octatone/Gif-Delayer",
@@ -14,18 +14,8 @@
       "matches": [
         "<all_urls>"
       ],
-      "css": [
-        "src/inject/inject.css"
-      ],
-      "run_at": "document_start"
-    },
-    {
-      "matches": [
-        "<all_urls>"
-      ],
       "js": [
-        "src/inject/vendor/jquery-2.0.3.js",
-        "src/inject/inject.js"
+        "src/inject/vendor/jquery-2.0.3.js"
       ],
       "run_at": "document_end"
     }
@@ -37,6 +27,12 @@
 
   "permissions": [
     "webRequest",
+    "storage",
+    "tabs",
     "*://*/"
-  ]
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My Test Extension Options</title>
+  <style>
+    body: { padding: 10px; }
+		#whitelist-holder { width: 100px; }
+		#whitelist { width: 365px; }
+  </style>
+</head>
+
+<body>
+	<div id="whitelist-holder">
+		Whitelisted Sites:<br>
+		<textarea name="whitelist" spellcheck="false" id="whitelist" autofocus rows="27" placeholder="Enter one domain per line, extension will format properly. Ex: mail.google.com and https://www.google.com will be handled as separate entires, both formats correct."></textarea>
+	</div>
+
+  <div id="status"></div>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,27 @@
+// Saves options to chrome.storage.sync.
+function save_options() {
+	var whitelist = document.getElementById('whitelist').value;
+  chrome.storage.sync.set({
+    whitelist: whitelist
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 1500);
+  });
+}
+
+// Restores state using the preferences stored in chrome.storage.
+function restore_options() {
+  chrome.storage.sync.get({
+    whitelist: ""
+  }, function(items) {
+    document.getElementById('whitelist').value = items.whitelist;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);


### PR DESCRIPTION
After using this extension for a number of years, I've run across a
handful of sites that use .gifs as button, etc. This extension wrongfully
targets them and often accidentally breaks the formatting and
functionality of the website.

My fix simply implements a whitelist of sites that disable the content
scripts through programmatic injection. Within background.js, my edits
check a parsed version of the contents of the whitelist versus the current
domain. If there are matches, the extension never executes any changes on
the page.

 - Contribution by Zach Hardesty: http://zachhardesty.com